### PR TITLE
Change text on homepage

### DIFF
--- a/src/main/webapp/app/core/home/home.vue
+++ b/src/main/webapp/app/core/home/home.vue
@@ -32,7 +32,7 @@
           Nachwuchskräften zu führen.
         </div>
         <br />
-        <div>Um einen unserer 90 Stellplätze zu buchen, geht es hier zur <a class="alert-link" v-on:click="openLogin()">Anmeldung</a>.</div>
+        <div>Um einen Stellplatz zu buchen, geht es hier zur <a class="alert-link" v-on:click="openLogin()">Anmeldung</a>.</div>
         <br />
         <div>
           Falls Sie noch keinen Zugang haben, können Sie sich hier


### PR DESCRIPTION
Text auf Startseite von BookABooth angepasst
Alter Text: Um einen unserer 90 Stellplätze zu buchen, geht es hier zur Anmeldung. Neuer Text: Um einen Stellplatz zu buchen, geht es hier zur Anmeldung.